### PR TITLE
Fix clippy warning for path_from_bytes return

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ cfg_if::cfg_if! {
         use std::ffi::OsStr;
         use std::os::unix::ffi::OsStrExt;
 
+        #[allow(clippy::unnecessary_wraps)]
         fn path_from_bytes(bytes: &[u8]) -> Result<&OsStr, Error> {
             Ok(OsStr::from_bytes(bytes))
         }


### PR DESCRIPTION
`path_from_bytes` is wrapped on the Linux implementation in order to
make it match the Windows implementation. This adds a clippy supression
to make sure that error does not show up on our CI build.